### PR TITLE
fix error when app.yaml includes int data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ def replace_env_variables_in_app_yaml_file():
 
     for key in yaml_data["env_variables"]:
         env_var = yaml_data["env_variables"][key]
-        if env_var.startswith("$"):
+        if type(env_var) is str and env_var.startswith("$"):
             repl_env_var = os.environ.get(env_var[1:])
             if repl_env_var is not None:
                 yaml_data["env_variables"][key] = repl_env_var


### PR DESCRIPTION
Thank you very much for the great workflow. It has been a great help to me.

When I have `app.yaml` like:
```yaml
env_variables:
  SOME_SECRET: $SOME_SECRET
  NOT_SECRET: 12345
```
I have encountered following error:
```
Traceback (most recent call last):
  File "/app/main.py", line 32, in <module>
    replace_env_variables_in_app_yaml_file()
  File "/app/main.py", line 20, in replace_env_variables_in_app_yaml_file
    if env_var.startswith("$"):
AttributeError: 'int' object has no attribute 'startswith'
```

I have fixed the error and the changes are now ready for review.
Thank you for your time and consideration.